### PR TITLE
Fix the issue that causes relay nodes to be queried under `sys` subdomain.

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@ static/css
 static/js
 static/favicon*.*
 **/docker-compose.yml
+*.md

--- a/config/config.js
+++ b/config/config.js
@@ -34,9 +34,7 @@ const config = {
   // TODO: how to do this through NAT?
   // 0.0.0.0 will bind all interfaces
   addresses: {
-    listen: [
-      `/ip4/0.0.0.0/tcp/${GOSSIP_PORT}`,
-    ],
+    listen: [`/ip4/0.0.0.0/tcp/${GOSSIP_PORT}`],
     // announce: []
   },
   allowedTopics: ['/ibp', '/ibp/services', '/ibp/healthCheck'],

--- a/server.js
+++ b/server.js
@@ -93,9 +93,7 @@ const mh = new MessageHandler({ datastore: ds, api: hc })
   const libp2p = await createLibp2p({
     peerId,
     addresses: cfg.addresses,
-    transports: [
-      new tcp(),
-    ],
+    transports: [new tcp()],
     streamMuxers: [mplex()],
     connectionEncryption: [new noise()],
     connectionManager: {
@@ -226,7 +224,10 @@ const mh = new MessageHandler({ datastore: ds, api: hc })
 
   async function checkServiceJobs() {
     // from now on all monitors check all services
-    const services = await ds.Service.findAll({ where: { type: 'rpc', status: 'active' } })
+    const services = await ds.Service.findAll({
+      where: { type: 'rpc', status: 'active' },
+      include: ['membershipLevel'],
+    })
     const members = await ds.Member.findAll({
       where: { status: 'active' },
       include: ['membershipLevel'],
@@ -253,7 +254,7 @@ const mh = new MessageHandler({ datastore: ds, api: hc })
           checkServiceQueue.add(
             'checkService',
             {
-              subdomain: member.membershipLevel.subdomain,
+              subdomain: service.membershipLevel.subdomain,
               member,
               service,
               monitorId: peerId.toString(),


### PR DESCRIPTION
- Fix for #26.
- Ignore markdown files while formatting.